### PR TITLE
[RFC] Initial attempt at building node-zwave-js

### DIFF
--- a/node-zwave-js/Makefile
+++ b/node-zwave-js/Makefile
@@ -1,0 +1,59 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NPM_NAME:=zwave-js
+PKG_NAME:=node-$(PKG_NPM_NAME)
+PKG_VERSION:=10.3.0
+PKG_RELEASE:=1
+
+PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
+PKG_SOURCE_URL:=http://registry.npmjs.org/$(PKG_NPM_NAME)/-/
+PKG_HASH:=4bf0d5f1cb130ad36c4126bf9979c44e50ffc4e9b45bd16ee35aba24427cf2ce
+
+PKG_BUILD_DEPENDS:=node/host node-serialport/host
+PKG_USE_MIPS16:=0
+
+PKG_MAINTAINER:=David Woodhouse <dwmw2@infradead.org>
+PKG_LICENSE:=MIT
+PKG_LICENSE_FILES:=LICENSE
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/node-zwave-js
+  SUBMENU:=Node.js
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Z-Wave device driver written entirely in JavaScript/TypeScript
+  URL:=https://zwave-js.github.io/node-zwave-js/#/
+  DEPENDS:=+node
+endef
+
+define Package/node-zwave-js/description
+ Z-Wave device driver written entirely in JavaScript/TypeScript
+endef
+
+NODEJS_CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))))
+
+define Build/Prepare
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)
+endef
+
+define Build/Compile
+	$(MAKE_VARS) \
+	$(MAKE_FLAGS) \
+	npm_config_arch=$(NODEJS_CPU) \
+	npm_config_nodedir=$(STAGING_DIR)/usr/ \
+	npm_config_cache=$(TMP_DIR)/npm-cache \
+	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
+	npm install --build-from-source --target_arch=$(NODEJS_CPU) -g $(DL_DIR)/$(PKG_SOURCE)
+endef
+
+define Package/node-zwave-js/install
+	$(INSTALL_DIR) $(1)/usr/lib/node
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/* $(1)/usr/lib/node/
+endef
+
+$(eval $(call BuildPackage,node-zwave-js))


### PR DESCRIPTION
This doesn't work; it dies with
```
find /home/dwmw2/git/lede/22.03/build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/node-zwave-js-10.3.0/ipkg-arm_cortex-a7_neon-vfpv4/node-zwave-js -name 'CVS' -o -name '.svn' -o -name '.#*' -o -name '*~'| xargs -r rm -rf
qggPackage node-zwave-js is missing dependencies for the following libraries:
libc.musl-x86_64.so.1
libc++_shared.so
libc.so.6
libdl.so
liblog.so
libm.so
libm.so.6
libpthread.so.0
make[2]: *** [Makefile:68: /home/dwmw2/git/lede/22.03/bin/packages/arm_cortex-a7_neon-vfpv4/packages/node-zwave-js_10.3.0-1_arm_cortex-a7_neon-vfpv4.ipk] Error 1
```
This is presumably because it finds these executables:
```
 cd  build_dir/target-arm_cortex-a7+neon-vfpv4_musl_eabi/node-zwave-js-10.3.0/ipkg-install/ && grep libc.so -r .
grep: ./usr/lib/node_modules/zwave-js/node_modules/@serialport/bindings-cpp/build/Release/obj.target/bindings.node: binary file matches
grep: ./usr/lib/node_modules/zwave-js/node_modules/@serialport/bindings-cpp/build/Release/bindings.node: binary file matches
grep: ./usr/lib/node_modules/zwave-js/node_modules/@serialport/bindings-cpp/prebuilds/android-arm64/node.napi.armv8.node: binary file matches
grep: ./usr/lib/node_modules/zwave-js/node_modules/@serialport/bindings-cpp/prebuilds/linux-arm64/node.napi.armv8.node: binary file matches
grep: ./usr/lib/node_modules/zwave-js/node_modules/@serialport/bindings-cpp/prebuilds/android-arm/node.napi.armv7.node: binary file matches
grep: ./usr/lib/node_modules/zwave-js/node_modules/@serialport/bindings-cpp/prebuilds/linux-arm/node.napi.armv7.node: binary file matches
grep: ./usr/lib/node_modules/zwave-js/node_modules/@serialport/bindings-cpp/prebuilds/linux-arm/node.napi.armv6.node: binary file matches
grep: ./usr/lib/node_modules/zwave-js/node_modules/@serialport/bindings-cpp/prebuilds/linux-x64/node.napi.glibc.node: binary file matches
```
I don't want those anyway; first thing to fix is making it use the existing OpenWrt node-serialport package, presumably?

Since Domoticz (as packaged in OpenWrt is migrating from OpenZWave to zwave-js, I need to work out how to get it working. But I have no clue about npm, yarn, and pkg.... have filed https://github.com/zwave-js/zwave-js-ui/issues/2797 on the zwave-js side but they're not familiar with OpenWrt packaging either.

Note that zwave-js is in npm and is the core dependency of zwave-js-ui which is going to be even harder to package, but let's start "simple"... :)
